### PR TITLE
Use nouns instead of verbs for type names

### DIFF
--- a/enveloped-application.json
+++ b/enveloped-application.json
@@ -1148,14 +1148,14 @@
       },
       "VerificationTypes": {
         "type": "array",
-        "description": "List of requested verifications:\n* watchlists - check user on PEPs (fields `First name` and `Last name` must be filled)\n* face-matching - compare photo on the document with selfie (selfie list and document list must be provided)\n* data-extraction - extract data from the documents (documents must be provided)\n* crosschecking - check the conformity between fields and extracted data\n\nIf the list isn't provided, all verifications will be applied.\n",
+        "description": "List of requested verifications:\n* watchlists - check user on PEPs (fields `First name` and `Last name` must be filled)\n* face-matching - compare photo on the document with selfie (selfie list and document list must be provided)\n* data-extraction - extract data from the documents (documents must be provided)\n* cross-checking - check the conformity between fields and extracted data\n\nIf the list isn't provided, all verifications will be applied.\n",
         "items": {
           "type": "string",
           "enum": [
             "watchlists",
             "face-matching",
             "data-extraction",
-            "crosschecking"
+            "cross-checking"
           ]
         },
         "example": [

--- a/enveloped-application.json
+++ b/enveloped-application.json
@@ -621,7 +621,7 @@
                 "comment": "found 2 reports against the person"
               },
               {
-                "service": "extract-data",
+                "service": "data-extraction",
                 "status": "approved",
                 "comment": "data was extracted"
               }
@@ -1148,20 +1148,20 @@
       },
       "VerificationTypes": {
         "type": "array",
-        "description": "List of requested verifications:\n* watchlists - check user on PEPs (fields `First name` and `Last name` must be filled)\n* face-matching - compare photo on the document with selfie (selfie list and document list must be provided)\n* extract-data - extract data from the documents (documents must be provided)\n* crosschecking - check the conformity between fields and extracted data\n\nIf the list isn't provided, all verifications will be applied.\n",
+        "description": "List of requested verifications:\n* watchlists - check user on PEPs (fields `First name` and `Last name` must be filled)\n* face-matching - compare photo on the document with selfie (selfie list and document list must be provided)\n* data-extraction - extract data from the documents (documents must be provided)\n* crosschecking - check the conformity between fields and extracted data\n\nIf the list isn't provided, all verifications will be applied.\n",
         "items": {
           "type": "string",
           "enum": [
             "watchlists",
             "face-matching",
-            "extract-data",
+            "data-extraction",
             "crosschecking"
           ]
         },
         "example": [
           "watchlists",
           "face-matching",
-          "extract-data"
+          "data-extraction"
         ]
       },
       "DocumentType": {

--- a/enveloped-application.yaml
+++ b/enveloped-application.yaml
@@ -816,12 +816,12 @@ components:
         * watchlists - check user on PEPs (fields `First name` and `Last name` must be filled)
         * face-matching - compare photo on the document with selfie (selfie list and document list must be provided)
         * data-extraction - extract data from the documents (documents must be provided)
-        * crosschecking - check the conformity between fields and extracted data
+        * cross-checking - check the conformity between fields and extracted data
 
         If the list isn't provided, all verifications will be applied.
       items:
         type: string
-        enum: ["watchlists", "face-matching", "data-extraction", "crosschecking"]
+        enum: ["watchlists", "face-matching", "data-extraction", "cross-checking"]
       example: ["watchlists", "face-matching", "data-extraction"]
 
     DocumentType:

--- a/enveloped-application.yaml
+++ b/enveloped-application.yaml
@@ -423,7 +423,7 @@ components:
             - service: watchlists
               status: declined
               comment: found 2 reports against the person
-            - service: extract-data
+            - service: data-extraction
               status: approved
               comment: data was extracted
         validationDate:
@@ -815,14 +815,14 @@ components:
         List of requested verifications:
         * watchlists - check user on PEPs (fields `First name` and `Last name` must be filled)
         * face-matching - compare photo on the document with selfie (selfie list and document list must be provided)
-        * extract-data - extract data from the documents (documents must be provided)
+        * data-extraction - extract data from the documents (documents must be provided)
         * crosschecking - check the conformity between fields and extracted data
 
         If the list isn't provided, all verifications will be applied.
       items:
         type: string
-        enum: ["watchlists", "face-matching", "extract-data", "crosschecking"]
-      example: ["watchlists", "face-matching", "extract-data"]
+        enum: ["watchlists", "face-matching", "data-extraction", "crosschecking"]
+      example: ["watchlists", "face-matching", "data-extraction"]
 
     DocumentType:
       type: string


### PR DESCRIPTION
`extract-data` - is an imperative form, but other verification types' names are nominative ones. Let's be consistent.